### PR TITLE
Rewrite test to not depend on gotest.tools 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,4 @@ require (
 	github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e
 	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible
 	github.com/pkg/errors v0.9.1
-	gotest.tools/v3 v3.0.3
 )

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-
 // Config represents configuration for the zfs plugin
 type Config struct {
 	// Root directory for the plugin


### PR DESCRIPTION
The test was only using some minimal functionality of gotest.tools, so tying to keep the requirements in go.mod down.

Relates to https://github.com/containerd/containerd/pull/5243/files#r598499586