### PR TITLE
plugin: initialize Config

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -31,8 +31,9 @@ type Config struct {
 
 func init() {
 	plugin.Register(&plugin.Registration{
-		Type: plugin.SnapshotPlugin,
-		ID:   "zfs",
+		Type:   plugin.SnapshotPlugin,
+		ID:     "zfs",
+		Config: &Config{},
 		InitFn: func(ic *plugin.InitContext) (interface{}, error) {
 			ic.Meta.Platforms = append(ic.Meta.Platforms, platforms.DefaultSpec())
 


### PR DESCRIPTION
Fixes https://github.com/containerd/zfs/issues/42

containerd will only load the plugin `Config` if it is not `nil` in the `Registration`.  When the `Config` is `nil`, the zfs plugin fails to start as the type assertion fails.
