### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
 
   checks:


### PR DESCRIPTION
The `ci` workflow runs Go test only. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.